### PR TITLE
Update Android folder name to Droid.

### DIFF
--- a/ImageMultiplier/ImageMultiplier.xft.xml
+++ b/ImageMultiplier/ImageMultiplier.xft.xml
@@ -15,11 +15,11 @@
 # Each SVG file is processes against the matching type specifiers to create
 # multiple PNG files in all of the sizes you need for your Android and iOS projects
 
-{ type: 'AndroidIcon', width: 36, color: '#f80c12', path: 'Android/Resources/drawable-ldpi/{0}' }
-{ type: 'AndroidIcon', width: 48, color: '#f80c12', path: 'Android/Resources/drawable-mdpi/{0}' }
-{ type: 'AndroidIcon', width: 72, color: '#f80c12', path: 'Android/Resources/drawable-hdpi/{0}' }
-{ type: 'AndroidIcon', width: 96, color: '#f80c12', path: 'Android/Resources/drawable-xhdpi/{0}' }
-{ type: 'AndroidIcon', width: 96, color: '#f80c12', path: 'Android/Resources/drawable/{0}' }
+{ type: 'AndroidIcon', width: 36, color: '#f80c12', path: 'Droid/Resources/drawable-ldpi/{0}' }
+{ type: 'AndroidIcon', width: 48, color: '#f80c12', path: 'Droid/Resources/drawable-mdpi/{0}' }
+{ type: 'AndroidIcon', width: 72, color: '#f80c12', path: 'Droid/Resources/drawable-hdpi/{0}' }
+{ type: 'AndroidIcon', width: 96, color: '#f80c12', path: 'Droid/Resources/drawable-xhdpi/{0}' }
+{ type: 'AndroidIcon', width: 96, color: '#f80c12', path: 'Droid/Resources/drawable/{0}' }
 
 { type: 'iosIcon', width:  32, path: 'iOS/Resources/{0}@1x' }
 { type: 'iosIcon', width:  29, path: 'iOS/Resources/{0}29@1x' }
@@ -29,7 +29,7 @@
 { type: 'iosIcon', width: 114, path: 'iOS/Resources/{0}57@2x' }
 { type: 'iosIcon', width: 120, path: 'iOS/Resources/{0}60@2x' }
 
-{ type: 'TabIcon', width: 52, color: '#f80c12', path: 'Android/Resources/drawable-ldpi{0}' }
+{ type: 'TabIcon', width: 52, color: '#f80c12', path: 'Droid/Resources/drawable-ldpi{0}' }
 { type: 'TabIcon', width: 52, path: 'iOS/Resources/{0}' }
 
 # You can process multiple directories, each with different type specifiers


### PR DESCRIPTION
Xamarin has changed the root folder name of the Android project in Xamarin Studio. The new folder is now \Droid in Xamarin Studio.
